### PR TITLE
追加実装/エラーメッセージの日本語化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,3 +71,5 @@ gem 'image_processing', '~> 1.2'
 gem 'pry-rails'
 
 gem 'payjp'
+
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.5.0)
       loofah (~> 2.19, >= 2.19.1)
+    rails-i18n (7.0.7)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.0.6.1)
       actionpack (= 6.0.6.1)
       activesupport (= 6.0.6.1)
@@ -331,6 +334,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rspec-rails (~> 4.0.0)
   rubocop
   sass-rails (~> 5)

--- a/app/models/buyer_destination.rb
+++ b/app/models/buyer_destination.rb
@@ -7,11 +7,11 @@ class BuyerDestination
     validates :user_id
     validates :item_id
     # destinationモデルのバリデーション
-    validates :post_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: 'is invalid. Include hyphen(-)' }
-    validates :area_id, numericality: { other_than: 1, message: "can't be blank" }
+    validates :post_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: "は無効な値です。ハイフン(-)を含めてください。", allow_blank: true }
+    validates :area_id, numericality: { other_than: 1, message: "を入力して下さい" }
     validates :city
     validates :address
-    validates :phone_number, format: { with: /\A[0-9]{10,11}\z/, message: 'is invalid' }
+    validates :phone_number, format: { with: /\A[0-9]{10,11}\z/, message: "は無効な値です。", allow_blank: true }
     # トークンのバリデーション
     validates :token
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,5 @@
 class Item < ApplicationRecord
-  with_options numericality: { other_than: 1, message: "can't be blank" } do
+  with_options numericality: { other_than: 1, message: "を入力してください" } do
     validates :category_id
     validates :item_condition_id
     validates :delivery_fee_id
@@ -7,8 +7,8 @@ class Item < ApplicationRecord
     validates :area_id
   end
 
-  validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999, message: "Out of setting range"}
-  validates :price, numericality: { only_integer: true, message: "Half-width number." }
+  validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999, message: "は範囲内を入力してください"}
+  validates :price, numericality: { only_integer: true, message: "半角を入力してください" }
 
   validates :image, :name, :description, presence: true
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ module Furima39440
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    # 日本語の言語設定
+    config.i18n.default_locale = :ja
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -9,7 +9,7 @@ ja:
         current_password: 現在のパスワード
         current_sign_in_at: 現在のログイン時刻
         current_sign_in_ip: 現在のログインIPアドレス
-        email: Eメール
+        email: メール
         encrypted_password: 暗号化パスワード
         failed_attempts: 失敗したログイン試行回数
         last_sign_in_at: 最終ログイン時刻

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,35 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        nickname: ニックネーム
+        birth_day: 生年月日
+        first_name: 名前
+        last_name: 名字
+        first_name_kana: 名前(フリガナ)
+        last_name_kana: 名字(フリガナ)
+      item:
+        description: 出品の説明
+        image: 画像
+        price: 価格
+        category_id: カテゴリー
+        item_condition_id: 商品の状態
+        delivery_fee_id: 配送料の負担
+        area_id: 発送元の地域
+        delivery_day_id: 発送までの日数
+        name: 商品名
+        user: ユーザー
+
+  activemodel:
+    attributes:
+      buyer_destination:
+        post_code: 郵便番号
+        area_id: 都道府県
+        city: 市区町村
+        address: 番地
+        building_name: 建物名
+        phone_number: 電話番号
+        token: クレジットカード情報
+        user_id: ユーザー
+        item_id: 商品
+      

--- a/spec/models/buyer_destination_spec.rb
+++ b/spec/models/buyer_destination_spec.rb
@@ -26,62 +26,62 @@ RSpec.describe BuyerDestination, type: :model do
       it 'user_idが空だと保存できない' do
         @buyer_destination.user_id = ''
         @buyer_destination.valid?
-        expect(@buyer_destination.errors.full_messages).to include("User can't be blank")
+        expect(@buyer_destination.errors.full_messages).to include("ユーザーを入力してください")
       end
       it 'item_idが空だと保存できない' do
         @buyer_destination.item_id = ''
         @buyer_destination.valid?
-        expect(@buyer_destination.errors.full_messages).to include("Item can't be blank")
+        expect(@buyer_destination.errors.full_messages).to include("商品を入力してください")
       end
       it '郵便番号が空だと保存できないこと' do
         @buyer_destination.post_code = ''
         @buyer_destination.valid?
-        expect(@buyer_destination.errors.full_messages).to include("Post code can't be blank")
+        expect(@buyer_destination.errors.full_messages).to include("郵便番号を入力してください")
       end
       it '郵便番号にハイフンがないと保存できないこと' do
         @buyer_destination.post_code = 1_234_567
         @buyer_destination.valid?
-        expect(@buyer_destination.errors.full_messages).to include('Post code is invalid. Include hyphen(-)')
+        expect(@buyer_destination.errors.full_messages).to include('郵便番号は無効な値です。ハイフン(-)を含めてください。')
       end
       it 'areaが未選択だとだと保存できないこと' do
         @buyer_destination.area_id = 1
         @buyer_destination.valid?
-        expect(@buyer_destination.errors.full_messages).to include("Area can't be blank")
+        expect(@buyer_destination.errors.full_messages).to include("都道府県を入力して下さい")
       end
       it '市区町村が空だと保存できないこと' do
         @buyer_destination.city = ''
         @buyer_destination.valid?
-        expect(@buyer_destination.errors.full_messages).to include("City can't be blank")
+        expect(@buyer_destination.errors.full_messages).to include("市区町村を入力してください")
       end
       it '番地が空だと保存できないこと' do
         @buyer_destination.address = ''
         @buyer_destination.valid?
-        expect(@buyer_destination.errors.full_messages).to include("Address can't be blank")
+        expect(@buyer_destination.errors.full_messages).to include("番地を入力してください")
       end
       it '電話番号が空だと保存できないこと' do
         @buyer_destination.phone_number = ''
         @buyer_destination.valid?
-        expect(@buyer_destination.errors.full_messages).to include("Phone number can't be blank")
+        expect(@buyer_destination.errors.full_messages).to include("電話番号を入力してください")
       end
       it '電話番号にハイフンがあると保存できないこと' do
         @buyer_destination.phone_number = '123 - 1234 - 1234'
         @buyer_destination.valid?
-        expect(@buyer_destination.errors.full_messages).to include('Phone number is invalid')
+        expect(@buyer_destination.errors.full_messages).to include('電話番号は無効な値です。')
       end
       it '電話番号が12桁以上あると保存できないこと' do
         @buyer_destination.phone_number = 12_345_678_910_123_111
         @buyer_destination.valid?
-        expect(@buyer_destination.errors.full_messages).to include('Phone number is invalid')
+        expect(@buyer_destination.errors.full_messages).to include('電話番号は無効な値です。')
       end
       it '電話番号が9桁以下あると保存できないこと' do
         @buyer_destination.phone_number = 12_345_678
         @buyer_destination.valid?
-        expect(@buyer_destination.errors.full_messages).to include('Phone number is invalid')
+        expect(@buyer_destination.errors.full_messages).to include('電話番号は無効な値です。')
       end
       it 'トークンが空だと保存できないこと' do
         @buyer_destination.token = ''
         @buyer_destination.valid?
-        expect(@buyer_destination.errors.full_messages).to include("Token can't be blank")
+        expect(@buyer_destination.errors.full_messages).to include("クレジットカード情報を入力してください")
       end
     end
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -21,79 +21,79 @@ RSpec.describe Item, type: :model do
       it 'imageが空だと出品できない' do
         @item.image = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Image can't be blank")
+        expect(@item.errors.full_messages).to include("画像を入力してください")
       end
 
       it 'nameが空だと出品できない' do
         @item.name = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Name can't be blank")
+        expect(@item.errors.full_messages).to include("商品名を入力してください")
       end
 
       it 'descriptionが空だと出品できない' do
         @item.description = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Description can't be blank")
+        expect(@item.errors.full_messages).to include("出品の説明を入力してください")
       end
 
       it 'categoryが未選択だと出品できない' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category can't be blank")
+        expect(@item.errors.full_messages).to include("カテゴリーを入力してください")
       end
 
       it 'item_conditionが未選択だと出品できない' do
         @item.item_condition_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Item condition can't be blank")
+        expect(@item.errors.full_messages).to include("商品の状態を入力してください")
       end
 
       it 'delivery_feeが未選択だと出品できない' do
         @item.delivery_fee_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery fee can't be blank")
+        expect(@item.errors.full_messages).to include("配送料の負担を入力してください")
       end
 
       it 'areaが未選択だと出品できない' do
         @item.area_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Area can't be blank")
+        expect(@item.errors.full_messages).to include("発送元の地域を入力してください")
       end
 
       it 'delivery_dayが未選択だと出品できない' do
         @item.delivery_day_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery day can't be blank")
+        expect(@item.errors.full_messages).to include("発送までの日数を入力してください")
       end
 
       it 'priceが空だと出品できない' do
         @item.price = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price Out of setting range", "Price Half-width number.")
+        expect(@item.errors.full_messages).to include("価格は範囲内を入力してください", "価格半角を入力してください")
       end
 
       it 'priceが全角数字だと出品できない' do
         @item.price = "２０００"
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price Out of setting range", "Price Half-width number.")
+        expect(@item.errors.full_messages).to include("価格は範囲内を入力してください", "価格半角を入力してください")
       end
 
       it 'priceが300円未満では出品できない' do
         @item.price = 290
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price Out of setting range")
+        expect(@item.errors.full_messages).to include("価格は範囲内を入力してください")
       end
 
       it 'priceが9_999_999円を超えると出品できない' do
         @item.price = 100000000
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price Out of setting range")
+        expect(@item.errors.full_messages).to include("価格は範囲内を入力してください")
       end
 
       it 'ユーザーが紐付いていなければ投稿できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include('User must exist')
+        expect(@item.errors.full_messages).to include('ユーザーを入力してください')
       end
 
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,13 +22,13 @@ RSpec.describe User, type: :model do
       it 'nicknameが空では登録できないこと' do
         @user.nickname = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Nickname can't be blank")
+        expect(@user.errors.full_messages).to include("ニックネームを入力してください")
       end
 
       it 'emailが空では登録できないこと' do
         @user.email = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Email can't be blank")
+        expect(@user.errors.full_messages).to include("メールを入力してください")
       end
 
       it '重複したemailが存在する場合登録できないこと' do
@@ -36,108 +36,108 @@ RSpec.describe User, type: :model do
         another_user = FactoryBot.build(:user)
         another_user.email = @user.email
         another_user.valid?
-        expect(another_user.errors.full_messages).to include("Email has already been taken")
+        expect(another_user.errors.full_messages).to include("メールはすでに存在します")
       end
 
       it 'emailは@を含まないと登録できない' do
         @user.email = 'testmail'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Email is invalid')
+        expect(@user.errors.full_messages).to include('メールは不正な値です')
       end
 
       it 'first_nameが空では登録できない' do
         @user.first_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name can't be blank")
+        expect(@user.errors.full_messages).to include("名前を入力してください")
       end
 
       it 'last_nameが空では登録できない' do
         @user.last_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name can't be blank")
+        expect(@user.errors.full_messages).to include("名字を入力してください")
       end
 
       it "名字は全角（漢字・ひらがな・カタカナ）でなければ登録できない" do
         @user.first_name = "kana"
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name は全角ひらがな、全角カタカナ、漢字で入力して下さい")
+        expect(@user.errors.full_messages).to include("名前は全角ひらがな、全角カタカナ、漢字で入力して下さい")
       end
 
       it "名前は全角（漢字・ひらがな・カタカナ）でなければ登録できない" do
         @user.last_name = "kana"
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name は全角ひらがな、全角カタカナ、漢字で入力して下さい")
+        expect(@user.errors.full_messages).to include("名字は全角ひらがな、全角カタカナ、漢字で入力して下さい")
       end
 
       it 'first_name_kanaが空では登録できない' do
         @user.first_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name kana can't be blank")
+        expect(@user.errors.full_messages).to include("名前(フリガナ)を入力してください")
       end
 
       it 'last_name_kanaが空では登録できない' do
         @user.last_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name kana can't be blank")
+        expect(@user.errors.full_messages).to include("名字(フリガナ)を入力してください")
       end
 
       it "first_name_kanaのフリガナは全角（カタカナ）でなければ登録できない" do
         @user.first_name_kana = "aiueo"
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name kana は全角カタカナで入力して下さい")
+        expect(@user.errors.full_messages).to include("名前(フリガナ)は全角カタカナで入力して下さい")
       end
 
       it "last_name_kanaのフリガナは全角（カタカナ）でなければ登録できない" do
         @user.last_name_kana = "aiueo"
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name kana は全角カタカナで入力して下さい")
+        expect(@user.errors.full_messages).to include("名字(フリガナ)は全角カタカナで入力して下さい")
       end
 
       it 'birthdayが空では登録できない' do
         @user.birth_day = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Birth day can't be blank")
+        expect(@user.errors.full_messages).to include("生年月日を入力してください")
       end
 
       it 'passwordが空では登録できないこと' do
         @user.password = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password can't be blank")
+        expect(@user.errors.full_messages).to include("パスワードを入力してください")
       end
 
       it 'passwordが5文字以下であれば登録できないこと' do
         @user.password = '1234a'
         @user.password_confirmation = '1234a'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password is too short (minimum is 6 characters)")
+        expect(@user.errors.full_messages).to include("パスワードは6文字以上で入力してください")
       end
 
       it 'passwordが半角数字のみのときに登録できないこと' do
         @user.password = '123456'
         @user.password_confirmation = '123456'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password は半角英数で入力して下さい")
+        expect(@user.errors.full_messages).to include("パスワードは半角英数で入力して下さい")
       end
 
       it 'passwordが半角英語のみのときに登録できないこと' do
         @user.password = 'abcdef'
         @user.password_confirmation = 'abcdef'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password は半角英数で入力して下さい")
+        expect(@user.errors.full_messages).to include("パスワードは半角英数で入力して下さい")
       end
 
       it 'passwordが全角のときに登録できないこと' do
         @user.password = '１２３４５A'
         @user.password_confirmation = '１２３４５A'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password は半角英数で入力して下さい")
+        expect(@user.errors.full_messages).to include("パスワードは半角英数で入力して下さい")
       end
 
       it 'passwordとpassword_confirmationが不一致では登録できないこと' do
         @user.password = '12345a'
         @user.password_confirmation = '123456a'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+        expect(@user.errors.full_messages).to include("パスワード（確認用）とパスワードの入力が一致しません")
       end
     end
   end


### PR DESCRIPTION
# What
エラーメッセージの日本語化を追加実装のため

# Why
エラーメッセージの日本語化を実装するため、英語のエラーメッセージ及び、カラム名を日本語に翻訳し、テストコードのエラーメッセージも変更する